### PR TITLE
Introduce isolated pool

### DIFF
--- a/src/Controller.sol
+++ b/src/Controller.sol
@@ -604,8 +604,19 @@ contract Controller is Initializable, ReentrancyGuard, IUniswapV3MintCallback, I
         );
     }
 
-    function getUtilizationRatio(uint256 _tokenId) external view returns (uint256, uint256) {
-        return ReaderLogic.getUtilizationRatio(assets[_tokenId]);
+    /**
+     * @notice Gets asset utilization ratios
+     * @param _assetId The id of asset pair
+     * @return sqrtAsset The utilization of sqrt asset
+     * @return stableAsset The utilization of stable asset
+     * @return underlyingAsset The utilization of underlying asset
+     */
+    function getUtilizationRatio(uint256 _assetId)
+        external
+        view
+        returns (uint256 sqrtAsset, uint256 stableAsset, uint256 underlyingAsset)
+    {
+        return ReaderLogic.getUtilizationRatio(assets[_assetId]);
     }
 
     function validateIRMParams(DataType.AssetRiskParams memory _assetRiskParams) internal pure {

--- a/src/Controller.sol
+++ b/src/Controller.sol
@@ -128,7 +128,10 @@ contract Controller is Initializable, ReentrancyGuard, IUniswapV3MintCallback, I
     }
 
     /**
-     * @notice Addes token pair
+     * @notice Adds token pair to the contract
+     * @dev Only operator can call this function.
+     * @param _addAssetParam parameters to define asset risk and interest rate model
+     * @return assetId The id of pair
      */
     function addPair(DataType.AddAssetParams memory _addAssetParam) external onlyOperator returns (uint256) {
         return _addPair(_addAssetParam);

--- a/src/Reader.sol
+++ b/src/Reader.sol
@@ -23,9 +23,9 @@ contract Reader {
     /**
      * @notice Gets vault delta.
      */
-    function getDelta(uint256 _assetId, uint256 _vaultId) external view returns (int256 _delta) {
-        DataType.AssetStatus memory asset = controller.getAsset(_assetId);
+    function getDelta(uint256 _pairId, uint256 _vaultId) external view returns (int256 _delta) {
+        DataType.PairStatus memory asset = controller.getAsset(_pairId);
 
-        return ReaderLogic.getDelta(asset.id, controller.getVault(_vaultId), controller.getSqrtPrice(_assetId));
+        return ReaderLogic.getDelta(asset.id, controller.getVault(_vaultId), controller.getSqrtPrice(_pairId));
     }
 }

--- a/src/interfaces/IController.sol
+++ b/src/interfaces/IController.sol
@@ -5,19 +5,19 @@ import "../libraries/DataType.sol";
 import "../libraries/logic/TradeLogic.sol";
 
 interface IController {
-    function tradePerp(uint256 _vaultId, uint256 _assetId, TradeLogic.TradeParams memory _tradeParams)
+    function tradePerp(uint256 _vaultId, uint256 _pairId, TradeLogic.TradeParams memory _tradeParams)
         external
         returns (DataType.TradeResult memory);
 
     function updateMargin(int256 _marginAmount) external returns (uint256 vaultId);
 
-    function getSqrtPrice(uint256 _assetId) external view returns (uint160);
+    function getSqrtPrice(uint256 _pairId) external view returns (uint160);
 
     function getVault(uint256 _id) external view returns (DataType.Vault memory);
 
-    function getAssetGroup() external view returns (DataType.AssetGroup memory);
+    function getAssetGroup() external view returns (DataType.PairGroup memory);
 
-    function getAsset(uint256 _assetId) external view returns (DataType.AssetStatus memory);
+    function getAsset(uint256 _id) external view returns (DataType.PairStatus memory);
 
     function getVaultStatus(uint256 _id) external returns (DataType.VaultStatusResult memory);
 }

--- a/src/interfaces/IController.sol
+++ b/src/interfaces/IController.sol
@@ -15,7 +15,7 @@ interface IController {
 
     function getVault(uint256 _id) external view returns (DataType.Vault memory);
 
-    function getAssetGroup() external view returns (DataType.PairGroup memory);
+    function getPairGroup() external view returns (DataType.PairGroup memory);
 
     function getAsset(uint256 _id) external view returns (DataType.PairStatus memory);
 

--- a/src/libraries/AssetGroupLib.sol
+++ b/src/libraries/AssetGroupLib.sol
@@ -5,22 +5,7 @@ import "./ScaledAsset.sol";
 import "./DataType.sol";
 
 library AssetGroupLib {
-    function setStableAssetId(DataType.AssetGroup storage _assetGroup, uint256 _stableAssetId) internal {
-        _assetGroup.stableAssetId = _stableAssetId;
-        appendTokenId(_assetGroup, _stableAssetId);
-    }
-
-    function appendTokenId(DataType.AssetGroup storage _assetGroup, uint256 _assetId) internal {
-        _assetGroup.assetIds.push(_assetId);
-    }
-
     function isAllow(DataType.AssetGroup memory _assetGroup, uint256 _assetId) internal pure returns (bool) {
-        for (uint256 i = 0; i < _assetGroup.assetIds.length; i++) {
-            if (_assetGroup.assetIds[i] == _assetId) {
-                return true;
-            }
-        }
-
-        return false;
+        return _assetId < _assetGroup.assetsCount;
     }
 }

--- a/src/libraries/AssetGroupLib.sol
+++ b/src/libraries/AssetGroupLib.sol
@@ -5,7 +5,7 @@ import "./ScaledAsset.sol";
 import "./DataType.sol";
 
 library AssetGroupLib {
-    function isAllow(DataType.AssetGroup memory _assetGroup, uint256 _assetId) internal pure returns (bool) {
-        return _assetId < _assetGroup.assetsCount;
+    function isAllow(DataType.PairGroup memory _assetGroup, uint256 _pairId) internal pure returns (bool) {
+        return _pairId < _assetGroup.assetsCount;
     }
 }

--- a/src/libraries/AssetLib.sol
+++ b/src/libraries/AssetLib.sol
@@ -5,7 +5,7 @@ import "./ScaledAsset.sol";
 import "./DataType.sol";
 
 library AssetLib {
-    function checkUnderlyingAsset(uint256 _assetId, DataType.AssetStatus memory underlyingAsset) internal pure {
-        require(_assetId != Constants.STABLE_ASSET_ID && underlyingAsset.id > 0, "ASSETID");
+    function checkUnderlyingAsset(DataType.AssetStatus memory underlyingAsset) internal pure {
+        require(underlyingAsset.id > 0, "ASSETID");
     }
 }

--- a/src/libraries/AssetLib.sol
+++ b/src/libraries/AssetLib.sol
@@ -5,7 +5,7 @@ import "./ScaledAsset.sol";
 import "./DataType.sol";
 
 library AssetLib {
-    function checkUnderlyingAsset(DataType.AssetStatus memory underlyingAsset) internal pure {
+    function checkUnderlyingAsset(DataType.PairStatus memory underlyingAsset) internal pure {
         require(underlyingAsset.id > 0, "ASSETID");
     }
 }

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.19;
 
 library Constants {
-    uint256 internal constant STABLE_ASSET_ID = 1;
-
     uint256 internal constant ONE = 1e18;
 
     // Reserve factor is 8%

--- a/src/libraries/DataType.sol
+++ b/src/libraries/DataType.sol
@@ -7,8 +7,8 @@ import "./InterestRateModel.sol";
 
 library DataType {
     struct AssetGroup {
-        uint256 stableAssetId;
-        uint256[] assetIds;
+        address stableTokenAddress;
+        uint256 assetsCount;
     }
 
     struct OwnVaults {
@@ -19,7 +19,8 @@ library DataType {
     struct AddAssetParams {
         address uniswapPool;
         DataType.AssetRiskParams assetRiskParams;
-        InterestRateModel.IRMParams irmParams;
+        InterestRateModel.IRMParams stableIrmParams;
+        InterestRateModel.IRMParams underlyingIrmParams;
         InterestRateModel.IRMParams squartIRMParams;
     }
 
@@ -31,15 +32,20 @@ library DataType {
 
     struct AssetStatus {
         uint256 id;
-        address token;
-        address supplyTokenAddress;
+        AssetPoolStatus stablePool;
+        AssetPoolStatus underlyingPool;
         AssetRiskParams riskParams;
-        ScaledAsset.TokenStatus tokenStatus;
         Perp.SqrtPerpAssetStatus sqrtAssetStatus;
         bool isMarginZero;
-        InterestRateModel.IRMParams irmParams;
         InterestRateModel.IRMParams squartIRMParams;
         uint256 lastUpdateTimestamp;
+    }
+
+    struct AssetPoolStatus {
+        address token;
+        address supplyTokenAddress;
+        ScaledAsset.TokenStatus tokenStatus;
+        InterestRateModel.IRMParams irmParams;
         uint256 accumulatedProtocolRevenue;
     }
 

--- a/src/libraries/DataType.sol
+++ b/src/libraries/DataType.sol
@@ -6,7 +6,7 @@ import "./Perp.sol";
 import "./InterestRateModel.sol";
 
 library DataType {
-    struct AssetGroup {
+    struct PairGroup {
         address stableTokenAddress;
         uint256 assetsCount;
     }
@@ -30,7 +30,7 @@ library DataType {
         int24 rebalanceThreshold;
     }
 
-    struct AssetStatus {
+    struct PairStatus {
         uint256 id;
         AssetPoolStatus stablePool;
         AssetPoolStatus underlyingPool;

--- a/src/libraries/DebtCalculator.sol
+++ b/src/libraries/DebtCalculator.sol
@@ -7,7 +7,7 @@ import "./Perp.sol";
 
 library DebtCalculator {
     function calculateDebtValue(
-        DataType.AssetStatus memory _underlyingAssetStatus,
+        DataType.PairStatus memory _underlyingAssetStatus,
         Perp.UserStatus memory _perpUserStatus,
         uint160 _sqrtPrice
     ) internal pure returns (uint256) {

--- a/src/libraries/PairGroupLib.sol
+++ b/src/libraries/PairGroupLib.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import "./ScaledAsset.sol";
 import "./DataType.sol";
 
-library AssetGroupLib {
+library PairGroupLib {
     function isAllow(DataType.PairGroup memory _assetGroup, uint256 _pairId) internal pure returns (bool) {
         return _pairId < _assetGroup.assetsCount;
     }

--- a/src/libraries/Perp.sol
+++ b/src/libraries/Perp.sol
@@ -127,7 +127,7 @@ library Perp {
     }
 
     function updateRebalanceFeeGrowth(
-        DataType.AssetStatus memory _assetStatusUnderlying,
+        DataType.PairStatus memory _assetStatusUnderlying,
         SqrtPerpAssetStatus storage _sqrtAssetStatus
     ) internal {
         // settle fee for rebalance position
@@ -170,7 +170,7 @@ library Perp {
      *       sqrt(a2) - sqrt(x)
      */
     function reallocate(
-        DataType.AssetStatus storage _assetStatusUnderlying,
+        DataType.PairStatus storage _assetStatusUnderlying,
         SqrtPerpAssetStatus storage _sqrtAssetStatus,
         bool _enableRevert
     ) internal returns (bool, int256 profit) {
@@ -231,7 +231,7 @@ library Perp {
     }
 
     function rebalanceForInRange(
-        DataType.AssetStatus storage _assetStatusUnderlying,
+        DataType.PairStatus storage _assetStatusUnderlying,
         SqrtPerpAssetStatus storage _sqrtAssetStatus,
         int24 _currentTick,
         uint128 _totalLiquidityAmount
@@ -277,7 +277,7 @@ library Perp {
      *       sqrt(x) - sqrt(a1)
      */
     function swapForOutOfRange(
-        DataType.AssetStatus storage _assetStatusUnderlying,
+        DataType.PairStatus storage _assetStatusUnderlying,
         SqrtPerpAssetStatus storage _sqrtAssetStatus,
         uint160 _currentSqrtPrice,
         int24 _tick,
@@ -321,7 +321,7 @@ library Perp {
         return liquidity;
     }
 
-    function settleUserBalance(DataType.AssetStatus storage _underlyingAssetStatus, UserStatus storage _userStatus)
+    function settleUserBalance(DataType.PairStatus storage _underlyingAssetStatus, UserStatus storage _userStatus)
         internal
         returns (bool)
     {
@@ -436,7 +436,7 @@ library Perp {
      * (L/sqrt{x}, L * sqrt{x})
      */
     function computeRequiredAmounts(
-        DataType.AssetStatus memory _underlyingAssetStatus,
+        DataType.PairStatus memory _underlyingAssetStatus,
         UserStatus memory _userStatus,
         int256 _tradeSqrtAmount
     ) internal returns (int256 requiredAmountUnderlying, int256 requiredAmountStable) {
@@ -478,7 +478,7 @@ library Perp {
     }
 
     function updatePosition(
-        DataType.AssetStatus storage _underlyingAssetStatus,
+        DataType.PairStatus storage _underlyingAssetStatus,
         UserStatus storage _userStatus,
         UpdatePerpParams memory _updatePerpParams,
         UpdateSqrtPerpParams memory _updateSqrtPerpParams
@@ -816,7 +816,7 @@ library Perp {
     }
 
     function updateRebalancePosition(
-        DataType.AssetStatus storage _assetStatusUnderlying,
+        DataType.PairStatus storage _assetStatusUnderlying,
         int256 _updateAmount0,
         int256 _updateAmount1
     ) internal {

--- a/src/libraries/PerpFee.sol
+++ b/src/libraries/PerpFee.sol
@@ -6,7 +6,7 @@ import "./Perp.sol";
 library PerpFee {
     using ScaledAsset for ScaledAsset.TokenStatus;
 
-    function computeUserFee(DataType.AssetStatus memory _assetStatus, Perp.UserStatus memory _userStatus)
+    function computeUserFee(DataType.PairStatus memory _assetStatus, Perp.UserStatus memory _userStatus)
         internal
         pure
         returns (int256 unrealizedFeeUnderlying, int256 unrealizedFeeStable)
@@ -34,7 +34,7 @@ library PerpFee {
         }
     }
 
-    function settleUserFee(DataType.AssetStatus memory _assetStatus, Perp.UserStatus storage _userStatus)
+    function settleUserFee(DataType.PairStatus memory _assetStatus, Perp.UserStatus storage _userStatus)
         internal
         returns (int256 totalFeeUnderlying, int256 totalFeeStable)
     {
@@ -59,7 +59,7 @@ library PerpFee {
     // Trade fee
 
     function computeTradeFee(
-        DataType.AssetStatus memory _underlyingAssetStatus,
+        DataType.PairStatus memory _underlyingAssetStatus,
         Perp.SqrtPositionStatus memory _sqrtPerp
     ) internal pure returns (int256 feeUnderlying, int256 feeStable) {
         int256 fee0;
@@ -84,7 +84,7 @@ library PerpFee {
     }
 
     function settleTradeFee(
-        DataType.AssetStatus memory _underlyingAssetStatus,
+        DataType.PairStatus memory _underlyingAssetStatus,
         Perp.SqrtPositionStatus storage _sqrtPerp
     ) internal returns (int256 feeUnderlying, int256 feeStable) {
         (feeUnderlying, feeStable) = computeTradeFee(_underlyingAssetStatus, _sqrtPerp);
@@ -95,10 +95,11 @@ library PerpFee {
 
     // Premium
 
-    function computePremium(
-        DataType.AssetStatus memory _underlyingAssetStatus,
-        Perp.SqrtPositionStatus memory _sqrtPerp
-    ) internal pure returns (int256 premium) {
+    function computePremium(DataType.PairStatus memory _underlyingAssetStatus, Perp.SqrtPositionStatus memory _sqrtPerp)
+        internal
+        pure
+        returns (int256 premium)
+    {
         if (_sqrtPerp.amount > 0) {
             premium = mulDivToInt256(
                 _underlyingAssetStatus.sqrtAssetStatus.supplyPremiumGrowth - _sqrtPerp.entryPremium, _sqrtPerp.amount
@@ -110,10 +111,10 @@ library PerpFee {
         }
     }
 
-    function settlePremium(
-        DataType.AssetStatus memory _underlyingAssetStatus,
-        Perp.SqrtPositionStatus storage _sqrtPerp
-    ) internal returns (int256 premium) {
+    function settlePremium(DataType.PairStatus memory _underlyingAssetStatus, Perp.SqrtPositionStatus storage _sqrtPerp)
+        internal
+        returns (int256 premium)
+    {
         premium = computePremium(_underlyingAssetStatus, _sqrtPerp);
 
         if (_sqrtPerp.amount > 0) {

--- a/src/libraries/PositionCalculator.sol
+++ b/src/libraries/PositionCalculator.sol
@@ -104,9 +104,7 @@ library PositionCalculator {
 
                 PositionParams memory positionParams;
                 if (_enableUnrealizedFeeCalculation) {
-                    positionParams = getPositionWithUnrealizedFee(
-                        _assets[Constants.STABLE_ASSET_ID], _assets[assetId], userStatus.perpTrade
-                    );
+                    positionParams = getPositionWithUnrealizedFee(_assets[assetId], userStatus.perpTrade);
                 } else {
                     positionParams = getPosition(userStatus.perpTrade);
                 }
@@ -130,12 +128,11 @@ library PositionCalculator {
     }
 
     function getPositionWithUnrealizedFee(
-        DataType.AssetStatus memory _stableAsset,
         DataType.AssetStatus memory _underlyingAsset,
         Perp.UserStatus memory _perpUserStatus
     ) internal pure returns (PositionParams memory positionParams) {
         (int256 unrealizedFeeUnderlying, int256 unrealizedFeeStable) =
-            PerpFee.computeUserFee(_underlyingAsset, _stableAsset.tokenStatus, _perpUserStatus);
+            PerpFee.computeUserFee(_underlyingAsset, _perpUserStatus);
 
         return PositionParams(
             _perpUserStatus.perp.entryValue + _perpUserStatus.sqrtPerp.entryValue + unrealizedFeeStable,

--- a/src/libraries/PositionCalculator.sol
+++ b/src/libraries/PositionCalculator.sol
@@ -25,7 +25,7 @@ library PositionCalculator {
         int256 amountUnderlying;
     }
 
-    function isDanger(mapping(uint256 => DataType.AssetStatus) storage _assets, DataType.Vault memory _vault)
+    function isDanger(mapping(uint256 => DataType.PairStatus) storage _assets, DataType.Vault memory _vault)
         internal
         view
     {
@@ -39,7 +39,7 @@ library PositionCalculator {
     }
 
     function isSafe(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault memory _vault,
         bool _isLiquidationCall
     ) internal view returns (int256 minDeposit) {
@@ -59,7 +59,7 @@ library PositionCalculator {
     }
 
     function calculateMinDeposit(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault memory _vault,
         bool _enableUnrealizedFeeCalculation
     ) internal view returns (int256 minDeposit, int256 vaultValue, bool hasPosition) {
@@ -89,7 +89,7 @@ library PositionCalculator {
      * @param _enableUnrealizedFeeCalculation If true calculation count unrealized fee.
      */
     function calculateMinValue(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault memory _vault,
         bool _enableUnrealizedFeeCalculation
     ) internal view returns (int256 minValue, int256 vaultValue, uint256 debtValue, bool hasPosition) {
@@ -128,7 +128,7 @@ library PositionCalculator {
     }
 
     function getPositionWithUnrealizedFee(
-        DataType.AssetStatus memory _underlyingAsset,
+        DataType.PairStatus memory _underlyingAsset,
         Perp.UserStatus memory _perpUserStatus
     ) internal pure returns (PositionParams memory positionParams) {
         (int256 unrealizedFeeUnderlying, int256 unrealizedFeeStable) =

--- a/src/libraries/Reallocation.sol
+++ b/src/libraries/Reallocation.sol
@@ -16,7 +16,7 @@ library Reallocation {
     /**
      * @notice Gets new available range
      */
-    function getNewRange(DataType.AssetStatus memory _assetStatusUnderlying, int24 _currentTick)
+    function getNewRange(DataType.PairStatus memory _assetStatusUnderlying, int24 _currentTick)
         internal
         view
         returns (int24 lower, int24 upper)
@@ -38,7 +38,7 @@ library Reallocation {
     }
 
     function _getNewRange(
-        DataType.AssetStatus memory _assetStatusUnderlying,
+        DataType.PairStatus memory _assetStatusUnderlying,
         ScaledAsset.TokenStatus memory _token0Status,
         ScaledAsset.TokenStatus memory _token1Status,
         int24 _currentTick,

--- a/src/libraries/Reallocation.sol
+++ b/src/libraries/Reallocation.sol
@@ -16,22 +16,22 @@ library Reallocation {
     /**
      * @notice Gets new available range
      */
-    function getNewRange(
-        DataType.AssetStatus memory _assetStatusUnderlying,
-        ScaledAsset.TokenStatus memory _assetStatusStable,
-        int24 _currentTick
-    ) internal view returns (int24 lower, int24 upper) {
+    function getNewRange(DataType.AssetStatus memory _assetStatusUnderlying, int24 _currentTick)
+        internal
+        view
+        returns (int24 lower, int24 upper)
+    {
         int24 tickSpacing = IUniswapV3Pool(_assetStatusUnderlying.sqrtAssetStatus.uniswapPool).tickSpacing();
 
         ScaledAsset.TokenStatus memory token0Status;
         ScaledAsset.TokenStatus memory token1Status;
 
         if (_assetStatusUnderlying.isMarginZero) {
-            token0Status = _assetStatusStable;
-            token1Status = _assetStatusUnderlying.tokenStatus;
+            token0Status = _assetStatusUnderlying.stablePool.tokenStatus;
+            token1Status = _assetStatusUnderlying.underlyingPool.tokenStatus;
         } else {
-            token0Status = _assetStatusUnderlying.tokenStatus;
-            token1Status = _assetStatusStable;
+            token0Status = _assetStatusUnderlying.underlyingPool.tokenStatus;
+            token1Status = _assetStatusUnderlying.stablePool.tokenStatus;
         }
 
         return _getNewRange(_assetStatusUnderlying, token0Status, token1Status, _currentTick, tickSpacing);

--- a/src/libraries/Trade.sol
+++ b/src/libraries/Trade.sol
@@ -12,7 +12,7 @@ import "./ScaledAsset.sol";
 library Trade {
     using ScaledAsset for ScaledAsset.TokenStatus;
 
-    function settleFee(DataType.AssetStatus storage _underlyingAssetStatus, Perp.UserStatus storage _perpUserStatus)
+    function settleFee(DataType.PairStatus storage _underlyingAssetStatus, Perp.UserStatus storage _perpUserStatus)
         internal
         returns (int256 fee, bool isSettled)
     {
@@ -34,7 +34,7 @@ library Trade {
     }
 
     function trade(
-        DataType.AssetStatus storage _underlyingAssetStatus,
+        DataType.PairStatus storage _underlyingAssetStatus,
         Perp.UserStatus storage _perpUserStatus,
         int256 _tradeAmount,
         int256 _tradeAmountSqrt
@@ -73,7 +73,7 @@ library Trade {
     }
 
     function settleUserBalanceAndFee(
-        DataType.AssetStatus storage _underlyingAssetStatus,
+        DataType.PairStatus storage _underlyingAssetStatus,
         Perp.UserStatus storage _userStatus
     ) internal returns (int256 underlyingFee, int256 stableFee, bool isSettled) {
         (underlyingFee, stableFee) = PerpFee.settleUserFee(_underlyingAssetStatus, _userStatus);

--- a/src/libraries/VaultLib.sol
+++ b/src/libraries/VaultLib.sol
@@ -6,19 +6,19 @@ import "./DataType.sol";
 import "./ScaledAsset.sol";
 
 library VaultLib {
-    using AssetGroupLib for DataType.AssetGroup;
+    using AssetGroupLib for DataType.PairGroup;
 
     uint256 internal constant MAX_VAULTS = 100;
 
-    function getUserStatus(DataType.AssetGroup storage _assetGroup, DataType.Vault storage _vault, uint256 _assetId)
+    function getUserStatus(DataType.PairGroup storage _assetGroup, DataType.Vault storage _vault, uint256 _pairId)
         internal
         returns (DataType.UserStatus storage userStatus)
     {
         checkVault(_vault, msg.sender);
 
-        require(_assetGroup.isAllow(_assetId), "ASSETID");
+        require(_assetGroup.isAllow(_pairId), "ASSETID");
 
-        userStatus = createOrGetUserStatus(_vault, _assetId);
+        userStatus = createOrGetUserStatus(_vault, _pairId);
     }
 
     function checkVault(DataType.Vault memory _vault, address _caller) internal pure {
@@ -26,17 +26,17 @@ library VaultLib {
         require(_vault.owner == _caller, "V2");
     }
 
-    function createOrGetUserStatus(DataType.Vault storage _vault, uint256 _assetId)
+    function createOrGetUserStatus(DataType.Vault storage _vault, uint256 _pairId)
         internal
         returns (DataType.UserStatus storage)
     {
         for (uint256 i = 0; i < _vault.openPositions.length; i++) {
-            if (_vault.openPositions[i].assetId == _assetId) {
+            if (_vault.openPositions[i].assetId == _pairId) {
                 return _vault.openPositions[i];
             }
         }
 
-        _vault.openPositions.push(DataType.UserStatus(_assetId, Perp.createPerpUserStatus()));
+        _vault.openPositions.push(DataType.UserStatus(_pairId, Perp.createPerpUserStatus()));
 
         return _vault.openPositions[_vault.openPositions.length - 1];
     }

--- a/src/libraries/VaultLib.sol
+++ b/src/libraries/VaultLib.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.8.19;
 
-import "./AssetGroupLib.sol";
+import "./PairGroupLib.sol";
 import "./DataType.sol";
 import "./ScaledAsset.sol";
 
 library VaultLib {
-    using AssetGroupLib for DataType.PairGroup;
+    using PairGroupLib for DataType.PairGroup;
 
     uint256 internal constant MAX_VAULTS = 100;
 

--- a/src/libraries/logic/ApplyInterestLogic.sol
+++ b/src/libraries/logic/ApplyInterestLogic.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import {TransferHelper} from "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
-import "../AssetGroupLib.sol";
 import "../Perp.sol";
 import "../ScaledAsset.sol";
 import "../AssetLib.sol";

--- a/src/libraries/logic/ApplyInterestLogic.sol
+++ b/src/libraries/logic/ApplyInterestLogic.sol
@@ -12,13 +12,20 @@ library ApplyInterestLogic {
 
     event InterestGrowthUpdated(
         uint256 assetId,
-        uint256 assetGrowth,
-        uint256 debtGrowth,
-        uint256 supplyPremiumGrowth,
-        uint256 borrowPremiumGrowth,
+        uint256 underlyingAssetGrowth,
+        uint256 underlyingDebtGrowth,
+        uint256 stableAssetGrowth,
+        uint256 stableDebtGrowth,
+        uint256 underlyingAccumulatedProtocolRevenue,
+        uint256 stableAccumulatedProtocolRevenue
+    );
+
+    event PremiumGrowthUpdated(
+        uint256 assetId,
+        uint256 borrowPremium0Growth,
+        uint256 borrowPremium1Growth,
         uint256 fee0Growth,
-        uint256 fee1Growth,
-        uint256 accumulatedProtocolRevenue
+        uint256 fee1Growth
     );
 
     function applyInterestForAssetGroup(
@@ -54,6 +61,7 @@ library ApplyInterestLogic {
         assetStatus.lastUpdateTimestamp = block.timestamp;
 
         emitInterestGrowthEvent(assetStatus);
+        emitPremiumGrowthEvent(assetStatus);
     }
 
     function applyInterestForPoolStatus(DataType.AssetPoolStatus storage _poolStatus, uint256 _lastUpdateTimestamp)
@@ -79,11 +87,20 @@ library ApplyInterestLogic {
             _assetStatus.id,
             _assetStatus.underlyingPool.tokenStatus.assetGrowth,
             _assetStatus.underlyingPool.tokenStatus.debtGrowth,
+            _assetStatus.stablePool.tokenStatus.assetGrowth,
+            _assetStatus.stablePool.tokenStatus.debtGrowth,
+            _assetStatus.underlyingPool.accumulatedProtocolRevenue,
+            _assetStatus.stablePool.accumulatedProtocolRevenue
+        );
+    }
+
+    function emitPremiumGrowthEvent(DataType.AssetStatus memory _assetStatus) internal {
+        emit PremiumGrowthUpdated(
+            _assetStatus.id,
             _assetStatus.sqrtAssetStatus.supplyPremiumGrowth,
             _assetStatus.sqrtAssetStatus.borrowPremiumGrowth,
             _assetStatus.sqrtAssetStatus.fee0Growth,
-            _assetStatus.sqrtAssetStatus.fee1Growth,
-            _assetStatus.underlyingPool.accumulatedProtocolRevenue
+            _assetStatus.sqrtAssetStatus.fee1Growth
         );
     }
 

--- a/src/libraries/logic/ApplyInterestLogic.sol
+++ b/src/libraries/logic/ApplyInterestLogic.sol
@@ -29,16 +29,16 @@ library ApplyInterestLogic {
     );
 
     function applyInterestForAssetGroup(
-        DataType.AssetGroup storage _assetGroup,
-        mapping(uint256 => DataType.AssetStatus) storage _assets
+        DataType.PairGroup storage _assetGroup,
+        mapping(uint256 => DataType.PairStatus) storage _assets
     ) external {
         for (uint256 i = 1; i < _assetGroup.assetsCount; i++) {
             applyInterestForToken(_assets, i);
         }
     }
 
-    function applyInterestForToken(mapping(uint256 => DataType.AssetStatus) storage _assets, uint256 _assetId) public {
-        DataType.AssetStatus storage assetStatus = _assets[_assetId];
+    function applyInterestForToken(mapping(uint256 => DataType.PairStatus) storage _assets, uint256 _pairId) public {
+        DataType.PairStatus storage assetStatus = _assets[_pairId];
 
         require(assetStatus.id > 0, "A0");
 
@@ -82,7 +82,7 @@ library ApplyInterestLogic {
         _poolStatus.accumulatedProtocolRevenue += _poolStatus.tokenStatus.updateScaler(interestRate);
     }
 
-    function emitInterestGrowthEvent(DataType.AssetStatus memory _assetStatus) internal {
+    function emitInterestGrowthEvent(DataType.PairStatus memory _assetStatus) internal {
         emit InterestGrowthUpdated(
             _assetStatus.id,
             _assetStatus.underlyingPool.tokenStatus.assetGrowth,
@@ -94,7 +94,7 @@ library ApplyInterestLogic {
         );
     }
 
-    function emitPremiumGrowthEvent(DataType.AssetStatus memory _assetStatus) internal {
+    function emitPremiumGrowthEvent(DataType.PairStatus memory _assetStatus) internal {
         emit PremiumGrowthUpdated(
             _assetStatus.id,
             _assetStatus.sqrtAssetStatus.supplyPremiumGrowth,
@@ -104,11 +104,11 @@ library ApplyInterestLogic {
         );
     }
 
-    function reallocate(mapping(uint256 => DataType.AssetStatus) storage _assets, uint256 _assetId)
+    function reallocate(mapping(uint256 => DataType.PairStatus) storage _assets, uint256 _pairId)
         external
         returns (bool reallocationHappened, int256 profit)
     {
-        DataType.AssetStatus storage underlyingAsset = _assets[_assetId];
+        DataType.PairStatus storage underlyingAsset = _assets[_pairId];
 
         AssetLib.checkUnderlyingAsset(underlyingAsset);
 

--- a/src/libraries/logic/IsolatedVaultLogic.sol
+++ b/src/libraries/logic/IsolatedVaultLogic.sol
@@ -18,37 +18,37 @@ library IsolatedVaultLogic {
     event IsolatedVaultClosed(uint256 vaultId, uint256 isolatedVaultId, uint256 marginAmount);
 
     function openIsolatedVault(
-        DataType.AssetGroup storage _assetGroup,
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        DataType.PairGroup storage _assetGroup,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
         DataType.Vault storage _isolatedVault,
         uint256 _depositAmount,
-        uint256 _assetId,
+        uint256 _pairId,
         TradeLogic.TradeParams memory _tradeParams
     ) external returns (DataType.TradeResult memory tradeResult) {
-        DataType.UserStatus storage perpUserStatus = VaultLib.getUserStatus(_assetGroup, _isolatedVault, _assetId);
+        DataType.UserStatus storage perpUserStatus = VaultLib.getUserStatus(_assetGroup, _isolatedVault, _pairId);
 
         _vault.margin -= int256(_depositAmount);
         _isolatedVault.margin += int256(_depositAmount);
 
         PositionCalculator.isSafe(_assets, _vault, false);
 
-        tradeResult = TradeLogic.execTrade(_assets, _isolatedVault, _assetId, perpUserStatus, _tradeParams);
+        tradeResult = TradeLogic.execTrade(_assets, _isolatedVault, _pairId, perpUserStatus, _tradeParams);
 
         emit IsolatedVaultOpened(_vault.id, _isolatedVault.id, _depositAmount);
     }
 
     function closeIsolatedVault(
-        DataType.AssetGroup storage _assetGroup,
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        DataType.PairGroup storage _assetGroup,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
         DataType.Vault storage _isolatedVault,
-        uint256 _assetId,
+        uint256 _pairId,
         CloseParams memory _closeParams
     ) external returns (DataType.TradeResult memory tradeResult) {
-        DataType.UserStatus storage perpUserStatus = VaultLib.getUserStatus(_assetGroup, _isolatedVault, _assetId);
+        DataType.UserStatus storage perpUserStatus = VaultLib.getUserStatus(_assetGroup, _isolatedVault, _pairId);
 
-        tradeResult = closeVault(_assets, _isolatedVault, _assetId, perpUserStatus, _closeParams);
+        tradeResult = closeVault(_assets, _isolatedVault, _pairId, perpUserStatus, _closeParams);
 
         // _isolatedVault.margin must be greater than 0
 
@@ -62,9 +62,9 @@ library IsolatedVaultLogic {
     }
 
     function closeVault(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
-        uint256 _assetId,
+        uint256 _pairId,
         DataType.UserStatus storage _userStatus,
         CloseParams memory _closeParams
     ) internal returns (DataType.TradeResult memory tradeResult) {
@@ -74,7 +74,7 @@ library IsolatedVaultLogic {
         return TradeLogic.execTrade(
             _assets,
             _vault,
-            _assetId,
+            _pairId,
             _userStatus,
             TradeLogic.TradeParams(
                 tradeAmount,

--- a/src/libraries/logic/LiquidationLogic.sol
+++ b/src/libraries/logic/LiquidationLogic.sol
@@ -31,7 +31,7 @@ library LiquidationLogic {
     );
 
     function execLiquidationCall(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
         DataType.Vault storage _mainVault,
         uint256 _closeRatio
@@ -90,7 +90,7 @@ library LiquidationLogic {
 
     function closePerp(
         uint256 _vaultId,
-        DataType.AssetStatus storage _underlyingAssetStatus,
+        DataType.PairStatus storage _underlyingAssetStatus,
         Perp.UserStatus storage _perpUserStatus,
         uint256 _closeRatio
     ) internal returns (int256 totalPayoff, uint256 penaltyAmount) {

--- a/src/libraries/logic/ReaderLogic.sol
+++ b/src/libraries/logic/ReaderLogic.sol
@@ -58,9 +58,14 @@ library ReaderLogic {
     /**
      * @notice Gets utilization ratio
      */
-    function getUtilizationRatio(DataType.AssetStatus memory _assetStatus) external pure returns (uint256, uint256) {
+    function getUtilizationRatio(DataType.AssetStatus memory _assetStatus)
+        external
+        pure
+        returns (uint256, uint256, uint256)
+    {
         return (
             _assetStatus.sqrtAssetStatus.getUtilizationRatio(),
+            _assetStatus.stablePool.tokenStatus.getUtilizationRatio(),
             _assetStatus.underlyingPool.tokenStatus.getUtilizationRatio()
         );
     }

--- a/src/libraries/logic/ReaderLogic.sol
+++ b/src/libraries/logic/ReaderLogic.sol
@@ -15,8 +15,6 @@ library ReaderLogic {
         DataType.Vault storage _vault,
         uint256 _mainVaultId
     ) external view returns (DataType.VaultStatusResult memory) {
-        DataType.AssetStatus memory stableAssetStatus = _assets[Constants.STABLE_ASSET_ID];
-
         DataType.SubVaultStatusResult[] memory subVaults =
             new DataType.SubVaultStatusResult[](_vault.openPositions.length);
 
@@ -37,7 +35,7 @@ library ReaderLogic {
             }
 
             (int256 unrealizedFeeUnderlying, int256 unrealizedFeeStable) =
-                PerpFee.computeUserFee(_assets[userStatus.assetId], stableAssetStatus.tokenStatus, userStatus.perpTrade);
+                PerpFee.computeUserFee(_assets[userStatus.assetId], userStatus.perpTrade);
 
             subVaults[i].unrealizedFee = PositionCalculator.calculateValue(
                 sqrtPrice, PositionCalculator.PositionParams(unrealizedFeeStable, 0, unrealizedFeeUnderlying)
@@ -61,7 +59,10 @@ library ReaderLogic {
      * @notice Gets utilization ratio
      */
     function getUtilizationRatio(DataType.AssetStatus memory _assetStatus) external pure returns (uint256, uint256) {
-        return (_assetStatus.sqrtAssetStatus.getUtilizationRatio(), _assetStatus.tokenStatus.getUtilizationRatio());
+        return (
+            _assetStatus.sqrtAssetStatus.getUtilizationRatio(),
+            _assetStatus.underlyingPool.tokenStatus.getUtilizationRatio()
+        );
     }
 
     // getInterest

--- a/src/libraries/logic/ReaderLogic.sol
+++ b/src/libraries/logic/ReaderLogic.sol
@@ -11,7 +11,7 @@ library ReaderLogic {
     using ScaledAsset for ScaledAsset.TokenStatus;
 
     function getVaultStatus(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
         uint256 _mainVaultId
     ) external view returns (DataType.VaultStatusResult memory) {
@@ -58,7 +58,7 @@ library ReaderLogic {
     /**
      * @notice Gets utilization ratio
      */
-    function getUtilizationRatio(DataType.AssetStatus memory _assetStatus)
+    function getUtilizationRatio(DataType.PairStatus memory _assetStatus)
         external
         pure
         returns (uint256, uint256, uint256)
@@ -72,13 +72,13 @@ library ReaderLogic {
 
     // getInterest
 
-    function getDelta(uint256 _assetId, DataType.Vault memory _vault, uint160 _sqrtPrice)
+    function getDelta(uint256 _pairId, DataType.Vault memory _vault, uint160 _sqrtPrice)
         internal
         pure
         returns (int256 _delta)
     {
         for (uint256 i; i < _vault.openPositions.length; i++) {
-            if (_assetId != _vault.openPositions[i].assetId) {
+            if (_pairId != _vault.openPositions[i].assetId) {
                 continue;
             }
 

--- a/src/libraries/logic/SettleUserFeeLogic.sol
+++ b/src/libraries/logic/SettleUserFeeLogic.sol
@@ -9,7 +9,7 @@ import "../UniHelper.sol";
 library SettleUserFeeLogic {
     event FeeCollected(uint256 vaultId, uint256 assetId, int256 feeCollected);
 
-    function settleUserFee(mapping(uint256 => DataType.AssetStatus) storage _assets, DataType.Vault storage _vault)
+    function settleUserFee(mapping(uint256 => DataType.PairStatus) storage _assets, DataType.Vault storage _vault)
         external
         returns (int256[] memory latestFees, bool isSettled)
     {
@@ -17,7 +17,7 @@ library SettleUserFeeLogic {
     }
 
     function settleUserFee(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
         uint256 _excludeAssetId
     ) public returns (int256[] memory latestFees, bool isSettledTotal) {

--- a/src/libraries/logic/SettleUserFeeLogic.sol
+++ b/src/libraries/logic/SettleUserFeeLogic.sol
@@ -26,12 +26,11 @@ library SettleUserFeeLogic {
         for (uint256 i = 0; i < _vault.openPositions.length; i++) {
             uint256 assetId = _vault.openPositions[i].assetId;
 
-            if (assetId == Constants.STABLE_ASSET_ID || assetId == _excludeAssetId) {
+            if (assetId == _excludeAssetId) {
                 continue;
             }
 
-            (int256 fee, bool isSettled) =
-                Trade.settleFee(_assets[assetId], _assets[Constants.STABLE_ASSET_ID], _vault.openPositions[i].perpTrade);
+            (int256 fee, bool isSettled) = Trade.settleFee(_assets[assetId], _vault.openPositions[i].perpTrade);
 
             isSettledTotal = isSettledTotal || isSettled;
 

--- a/src/libraries/logic/SettleUserFeeLogic.sol
+++ b/src/libraries/logic/SettleUserFeeLogic.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.8.19;
 
-import "../AssetGroupLib.sol";
 import "../Trade.sol";
 import "../ScaledAsset.sol";
 import "../UniHelper.sol";

--- a/src/libraries/logic/SupplyLogic.sol
+++ b/src/libraries/logic/SupplyLogic.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.19;
 import {TransferHelper} from "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "../../interfaces/ISupplyToken.sol";
-import "../AssetGroupLib.sol";
 import "../DataType.sol";
 import "../PositionCalculator.sol";
 import "../ScaledAsset.sol";

--- a/src/libraries/logic/SupplyLogic.sol
+++ b/src/libraries/logic/SupplyLogic.sol
@@ -30,7 +30,7 @@ library SupplyLogic {
         );
     }
 
-    function supply(DataType.AssetStatus storage _asset, uint256 _amount, bool _isStable)
+    function supply(DataType.PairStatus storage _asset, uint256 _amount, bool _isStable)
         external
         returns (uint256 mintAmount)
     {
@@ -51,7 +51,7 @@ library SupplyLogic {
         ISupplyToken(_pool.supplyTokenAddress).mint(msg.sender, mintAmount);
     }
 
-    function withdraw(DataType.AssetStatus storage _asset, uint256 _amount, bool _isStable)
+    function withdraw(DataType.PairStatus storage _asset, uint256 _amount, bool _isStable)
         external
         returns (uint256 finalburntAmount, uint256 finalWithdrawalAmount)
     {

--- a/src/libraries/logic/SupplyLogic.sol
+++ b/src/libraries/logic/SupplyLogic.sol
@@ -24,34 +24,57 @@ library SupplyLogic {
             new SupplyToken(
             address(this),
             string.concat("Predy-Supply-", erc20.name()),
-            string.concat("p", erc20.symbol())
+            string.concat("p", erc20.symbol()),
+            erc20.decimals()
             )
         );
     }
 
-    function supply(DataType.AssetStatus storage _asset, uint256 _amount) external returns (uint256 mintAmount) {
-        mintAmount = _asset.tokenStatus.addAsset(_amount);
-
-        TransferHelper.safeTransferFrom(_asset.token, msg.sender, address(this), _amount);
-
-        ISupplyToken(_asset.supplyTokenAddress).mint(msg.sender, mintAmount);
+    function supply(DataType.AssetStatus storage _asset, uint256 _amount, bool _isStable)
+        external
+        returns (uint256 mintAmount)
+    {
+        if (_isStable) {
+            mintAmount = _supply(_asset.stablePool, _amount);
+        } else {
+            mintAmount = _supply(_asset.underlyingPool, _amount);
+        }
 
         emit TokenSupplied(msg.sender, _asset.id, _amount);
     }
 
-    function withdraw(DataType.AssetStatus storage _asset, uint256 _amount)
+    function _supply(DataType.AssetPoolStatus storage _pool, uint256 _amount) internal returns (uint256 mintAmount) {
+        mintAmount = _pool.tokenStatus.addAsset(_amount);
+
+        TransferHelper.safeTransferFrom(_pool.token, msg.sender, address(this), _amount);
+
+        ISupplyToken(_pool.supplyTokenAddress).mint(msg.sender, mintAmount);
+    }
+
+    function withdraw(DataType.AssetStatus storage _asset, uint256 _amount, bool _isStable)
         external
         returns (uint256 finalburntAmount, uint256 finalWithdrawalAmount)
     {
-        address supplyTokenAddress = _asset.supplyTokenAddress;
+        if (_isStable) {
+            (finalburntAmount, finalWithdrawalAmount) = _withdraw(_asset.stablePool, _amount);
+        } else {
+            (finalburntAmount, finalWithdrawalAmount) = _withdraw(_asset.underlyingPool, _amount);
+        }
+
+        emit TokenWithdrawn(msg.sender, _asset.id, finalWithdrawalAmount);
+    }
+
+    function _withdraw(DataType.AssetPoolStatus storage _pool, uint256 _amount)
+        internal
+        returns (uint256 finalburntAmount, uint256 finalWithdrawalAmount)
+    {
+        address supplyTokenAddress = _pool.supplyTokenAddress;
 
         (finalburntAmount, finalWithdrawalAmount) =
-            _asset.tokenStatus.removeAsset(IERC20(supplyTokenAddress).balanceOf(msg.sender), _amount);
+            _pool.tokenStatus.removeAsset(IERC20(supplyTokenAddress).balanceOf(msg.sender), _amount);
 
         ISupplyToken(supplyTokenAddress).burn(msg.sender, finalburntAmount);
 
-        TransferHelper.safeTransfer(_asset.token, msg.sender, finalWithdrawalAmount);
-
-        emit TokenWithdrawn(msg.sender, _asset.id, finalWithdrawalAmount);
+        TransferHelper.safeTransfer(_pool.token, msg.sender, finalWithdrawalAmount);
     }
 }

--- a/src/libraries/logic/TradeLogic.sol
+++ b/src/libraries/logic/TradeLogic.sol
@@ -39,19 +39,13 @@ library TradeLogic {
         TradeParams memory _tradeParams
     ) public returns (DataType.TradeResult memory tradeResult) {
         DataType.AssetStatus storage underlyingAssetStatus = _assets[_assetId];
-        DataType.AssetStatus storage stableAssetStatus = _assets[Constants.STABLE_ASSET_ID];
 
-        AssetLib.checkUnderlyingAsset(_assetId, underlyingAssetStatus);
+        AssetLib.checkUnderlyingAsset(underlyingAssetStatus);
 
         checkDeadline(_tradeParams.deadline);
 
-        tradeResult = trade(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            _userStatus.perpTrade,
-            _tradeParams.tradeAmount,
-            _tradeParams.tradeAmountSqrt
-        );
+        tradeResult =
+            trade(underlyingAssetStatus, _userStatus.perpTrade, _tradeParams.tradeAmount, _tradeParams.tradeAmountSqrt);
 
         _vault.margin += tradeResult.fee + tradeResult.payoff.perpPayoff + tradeResult.payoff.sqrtPayoff;
 
@@ -67,7 +61,7 @@ library TradeLogic {
 
             _vault.margin += marginAmount;
 
-            UpdateMarginLogic.execMarginTransfer(_vault, stableAssetStatus.token, marginAmount);
+            UpdateMarginLogic.execMarginTransfer(_vault, underlyingAssetStatus.stablePool.token, marginAmount);
 
             UpdateMarginLogic.emitEvent(_vault, marginAmount);
         }
@@ -86,12 +80,11 @@ library TradeLogic {
 
     function trade(
         DataType.AssetStatus storage _underlyingAssetStatus,
-        DataType.AssetStatus storage _stableAssetStatus,
         Perp.UserStatus storage _perpUserStatus,
         int256 _tradeAmount,
         int256 _tradeAmountSqrt
     ) public returns (DataType.TradeResult memory) {
-        return Trade.trade(_underlyingAssetStatus, _stableAssetStatus, _perpUserStatus, _tradeAmount, _tradeAmountSqrt);
+        return Trade.trade(_underlyingAssetStatus, _perpUserStatus, _tradeAmount, _tradeAmountSqrt);
     }
 
     function checkDeadline(uint256 _deadline) internal view {

--- a/src/libraries/logic/TradeLogic.sol
+++ b/src/libraries/logic/TradeLogic.sol
@@ -32,13 +32,13 @@ library TradeLogic {
     );
 
     function execTrade(
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
-        uint256 _assetId,
+        uint256 _pairId,
         DataType.UserStatus storage _userStatus,
         TradeParams memory _tradeParams
     ) public returns (DataType.TradeResult memory tradeResult) {
-        DataType.AssetStatus storage underlyingAssetStatus = _assets[_assetId];
+        DataType.PairStatus storage underlyingAssetStatus = _assets[_pairId];
 
         AssetLib.checkUnderlyingAsset(underlyingAssetStatus);
 
@@ -79,7 +79,7 @@ library TradeLogic {
     }
 
     function trade(
-        DataType.AssetStatus storage _underlyingAssetStatus,
+        DataType.PairStatus storage _underlyingAssetStatus,
         Perp.UserStatus storage _perpUserStatus,
         int256 _tradeAmount,
         int256 _tradeAmountSqrt

--- a/src/libraries/logic/UpdateMarginLogic.sol
+++ b/src/libraries/logic/UpdateMarginLogic.sol
@@ -12,6 +12,7 @@ library UpdateMarginLogic {
     event MarginUpdated(uint256 vaultId, int256 marginAmount);
 
     function updateMargin(
+        DataType.AssetGroup memory _assetGroup,
         mapping(uint256 => DataType.AssetStatus) storage _assets,
         DataType.Vault storage _vault,
         int256 _marginAmount
@@ -26,7 +27,7 @@ library UpdateMarginLogic {
 
         PositionCalculator.isSafe(_assets, _vault, false);
 
-        execMarginTransfer(_vault, getStableToken(_assets), _marginAmount);
+        execMarginTransfer(_vault, _assetGroup.stableTokenAddress, _marginAmount);
 
         emitEvent(_vault, _marginAmount);
     }
@@ -41,9 +42,5 @@ library UpdateMarginLogic {
 
     function emitEvent(DataType.Vault memory _vault, int256 _marginAmount) internal {
         emit MarginUpdated(_vault.id, _marginAmount);
-    }
-
-    function getStableToken(mapping(uint256 => DataType.AssetStatus) storage _assets) internal view returns (address) {
-        return _assets[Constants.STABLE_ASSET_ID].token;
     }
 }

--- a/src/libraries/logic/UpdateMarginLogic.sol
+++ b/src/libraries/logic/UpdateMarginLogic.sol
@@ -12,8 +12,8 @@ library UpdateMarginLogic {
     event MarginUpdated(uint256 vaultId, int256 marginAmount);
 
     function updateMargin(
-        DataType.AssetGroup memory _assetGroup,
-        mapping(uint256 => DataType.AssetStatus) storage _assets,
+        DataType.PairGroup memory _assetGroup,
+        mapping(uint256 => DataType.PairStatus) storage _assets,
         DataType.Vault storage _vault,
         int256 _marginAmount
     ) external {

--- a/src/strategy/GammaShortStrategy.sol
+++ b/src/strategy/GammaShortStrategy.sol
@@ -63,12 +63,12 @@ contract GammaShortStrategy is BaseStrategy, ReentrancyGuard, IStrategyVault, IP
     function initialize(
         address _controller,
         address _reader,
-        uint256 _assetId,
+        uint256 _pairId,
         MinPerValueLimit memory _minPerValueLimit,
         string memory _name,
         string memory _symbol
     ) public initializer {
-        BaseStrategy.initialize(_controller, _assetId, _minPerValueLimit, _name, _symbol);
+        BaseStrategy.initialize(_controller, _pairId, _minPerValueLimit, _name, _symbol);
         reader = Reader(_reader);
 
         // square root of 7.5% scaled by 1e18
@@ -77,7 +77,7 @@ contract GammaShortStrategy is BaseStrategy, ReentrancyGuard, IStrategyVault, IP
         hedgeInterval = 2 days;
 
         // initialize last sqrt price and timestamp
-        lastHedgePrice = controller.getSqrtPrice(_assetId);
+        lastHedgePrice = controller.getSqrtPrice(_pairId);
         lastHedgeTimestamp = block.timestamp;
     }
 
@@ -307,7 +307,7 @@ contract GammaShortStrategy is BaseStrategy, ReentrancyGuard, IStrategyVault, IP
         _mint(_recepient, _strategyTokenAmount);
 
         {
-            DataType.AssetStatus memory asset = controller.getAsset(assetId);
+            DataType.PairStatus memory asset = controller.getAsset(assetId);
 
             UniHelper.checkPriceByTWAP(asset.sqrtAssetStatus.uniswapPool);
         }

--- a/src/strategy/base/BaseStrategy.sol
+++ b/src/strategy/base/BaseStrategy.sol
@@ -48,9 +48,9 @@ contract BaseStrategy is ERC20Upgradeable {
 
         minPerValueLimit = _minPerValueLimit;
 
-        DataType.AssetStatus memory asset = controller.getAsset(Constants.STABLE_ASSET_ID);
+        DataType.AssetStatus memory asset = controller.getAsset(assetId);
 
-        usdc = asset.token;
+        usdc = asset.stablePool.token;
 
         operator = msg.sender;
     }

--- a/src/strategy/base/BaseStrategy.sol
+++ b/src/strategy/base/BaseStrategy.sol
@@ -35,7 +35,7 @@ contract BaseStrategy is ERC20Upgradeable {
 
     function initialize(
         address _controller,
-        uint256 _assetId,
+        uint256 _pairId,
         MinPerValueLimit memory _minPerValueLimit,
         string memory _name,
         string memory _symbol
@@ -44,11 +44,11 @@ contract BaseStrategy is ERC20Upgradeable {
 
         controller = IController(_controller);
 
-        assetId = _assetId;
+        assetId = _pairId;
 
         minPerValueLimit = _minPerValueLimit;
 
-        DataType.AssetStatus memory asset = controller.getAsset(assetId);
+        DataType.PairStatus memory asset = controller.getAsset(assetId);
 
         usdc = asset.stablePool.token;
 

--- a/src/tokenization/SupplyToken.sol
+++ b/src/tokenization/SupplyToken.sol
@@ -6,14 +6,22 @@ import "../interfaces/ISupplyToken.sol";
 
 contract SupplyToken is ERC20, ISupplyToken {
     address immutable controller;
+    uint8 _decimals;
 
     modifier onlyController() {
         require(controller == msg.sender, "ST0");
         _;
     }
 
-    constructor(address _controller, string memory _name, string memory _symbol) ERC20(_name, _symbol) {
+    constructor(address _controller, string memory _name, string memory _symbol, uint8 __decimals)
+        ERC20(_name, _symbol)
+    {
         controller = _controller;
+        _decimals = __decimals;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
     }
 
     function mint(address account, uint256 amount) external virtual override onlyController {

--- a/test/PerpFee.t.sol
+++ b/test/PerpFee.t.sol
@@ -6,7 +6,7 @@ import "../src/libraries/PerpFee.sol";
 import "./helper/Helper.sol";
 
 contract PerpFeeTest is Test, Helper {
-    DataType.AssetStatus underlyingAssetStatus;
+    DataType.PairStatus underlyingAssetStatus;
     ScaledAsset.TokenStatus stableAssetStatus;
     Perp.UserStatus perpUserStatus;
 

--- a/test/PerpFee.t.sol
+++ b/test/PerpFee.t.sol
@@ -3,33 +3,17 @@ pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
 import "../src/libraries/PerpFee.sol";
+import "./helper/Helper.sol";
 
-contract PerpFeeTest is Test {
+contract PerpFeeTest is Test, Helper {
     DataType.AssetStatus underlyingAssetStatus;
     ScaledAsset.TokenStatus stableAssetStatus;
     Perp.UserStatus perpUserStatus;
 
     function setUp() public {
-        underlyingAssetStatus = DataType.AssetStatus(
-            1,
-            address(0),
-            address(0),
-            DataType.AssetRiskParams(0, 1000, 500),
-            ScaledAsset.createTokenStatus(),
-            Perp.createAssetStatus(address(0), -100, 100),
-            false,
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            block.timestamp,
-            0
-        );
+        underlyingAssetStatus = createAssetStatus(1, address(0), address(0));
         stableAssetStatus = ScaledAsset.createTokenStatus();
         perpUserStatus = Perp.createPerpUserStatus();
-
-        underlyingAssetStatus.sqrtAssetStatus.supplyPremiumGrowth = 1 * 1e16;
-        underlyingAssetStatus.sqrtAssetStatus.borrowPremiumGrowth = 2 * 1e16;
-        underlyingAssetStatus.sqrtAssetStatus.fee0Growth = 200 * 1e12;
-        underlyingAssetStatus.sqrtAssetStatus.fee1Growth = 5 * 1e12;
     }
 
     function testComputeTradeFeeForLong() public {

--- a/test/Reader.t.sol
+++ b/test/Reader.t.sol
@@ -23,8 +23,8 @@ contract TestReader is TestController {
         vm.startPrank(user1);
         usdc.approve(address(controller), type(uint256).max);
         weth.approve(address(controller), type(uint256).max);
-        controller.supplyToken(1, 1e10);
-        controller.supplyToken(2, 1e10);
+        controller.supplyToken(1, 1e10, true);
+        controller.supplyToken(1, 1e10, false);
         vaultId1 = controller.updateMargin(1e10);
         vm.stopPrank();
 

--- a/test/Reallocation.t.sol
+++ b/test/Reallocation.t.sol
@@ -7,7 +7,7 @@ import "../src/libraries/InterestRateModel.sol";
 import "./helper/Helper.sol";
 
 contract ReallocationTest is Test, Helper {
-    DataType.AssetStatus underlyingAssetStatus;
+    DataType.PairStatus underlyingAssetStatus;
     ScaledAsset.TokenStatus stableScaledTokenStatus;
     ScaledAsset.TokenStatus underlyingScaledTokenStatus;
 

--- a/test/controller/Callback.t.sol
+++ b/test/controller/Callback.t.sol
@@ -14,16 +14,12 @@ contract TestControllerCallback is TestController {
         usdc.mint(user, type(uint128).max);
         weth.mint(user, type(uint128).max);
 
-        vm.prank(user);
+        vm.startPrank(user);
         usdc.approve(address(controller), type(uint256).max);
-
-        vm.prank(user);
         weth.approve(address(controller), type(uint256).max);
-
-        vm.prank(user);
-        controller.supplyToken(1, 1e10);
-        vm.prank(user);
-        controller.supplyToken(2, 1e10);
+        controller.supplyToken(1, 1e10, true);
+        controller.supplyToken(1, 1e10, false);
+        vm.stopPrank();
 
         vaultId = controller.updateMargin(1e8);
     }

--- a/test/controller/IsolatedVault.t.sol
+++ b/test/controller/IsolatedVault.t.sol
@@ -20,8 +20,8 @@ contract TestControllerIsolatedVault is TestController {
         vm.startPrank(user1);
         usdc.approve(address(controller), type(uint256).max);
         weth.approve(address(controller), type(uint256).max);
-        controller.supplyToken(1, 1e10);
-        controller.supplyToken(2, 1e10);
+        controller.supplyToken(1, 1e10, true);
+        controller.supplyToken(1, 1e10, false);
         vaultId1 = controller.updateMargin(1e10);
         vm.stopPrank();
 

--- a/test/controller/LiquidationCall.t.sol
+++ b/test/controller/LiquidationCall.t.sol
@@ -19,17 +19,18 @@ contract TestControllerLiquidationCall is TestController {
 
         usdc.mint(user2, type(uint128).max);
         weth.mint(user2, type(uint128).max);
+        wbtc.mint(user2, type(uint128).max);
 
-        vm.prank(user2);
+        vm.startPrank(user2);
         usdc.approve(address(controller), type(uint256).max);
-
-        vm.prank(user2);
         weth.approve(address(controller), type(uint256).max);
+        wbtc.approve(address(controller), type(uint256).max);
 
-        vm.prank(user2);
-        controller.supplyToken(1, 1e10, true);
-        vm.prank(user2);
-        controller.supplyToken(1, 1e10, false);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, true);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, false);
+        controller.supplyToken(WBTC_ASSET_ID, 1e10, true);
+        controller.supplyToken(WBTC_ASSET_ID, 1e10, false);
+        vm.stopPrank();
 
         // create vault
         vaultId = controller.updateMargin(1e8);
@@ -197,5 +198,30 @@ contract TestControllerLiquidationCall is TestController {
 
         // check liquidation reward
         assertEq(usdc.balanceOf(liquidator), 200000);
+    }
+
+    // liquidates a vault that has multiple asset positions.
+    function testLiquidationCallWithMultipleAssets() public {
+        controller.tradePerp(vaultId, WETH_ASSET_ID, getTradeParams(-4 * 1e8, 2 * 1e8));
+        controller.tradePerp(vaultId, WBTC_ASSET_ID, getTradeParams(-4 * 1e8, 2 * 1e8));
+
+        uniswapPool.swap(address(this), false, 5 * 1e16, TickMath.MAX_SQRT_RATIO - 1, "");
+        wbtcUniswapPool.swap(address(this), false, 5 * 1e16, TickMath.MAX_SQRT_RATIO - 1, "");
+
+        vm.warp(block.timestamp + 1 weeks);
+
+        DataType.VaultStatusResult memory vaultStatus = controller.getVaultStatus(vaultId);
+        assertEq(vaultStatus.vaultValue, 68418616);
+        assertEq(vaultStatus.minDeposit, 93054574);
+
+        vm.prank(liquidator);
+        controller.liquidationCall(vaultId, 1e18);
+
+        DataType.Vault memory vault = controller.getVault(vaultId);
+
+        assertEq(vault.margin, 67350000);
+
+        // check liquidation reward
+        assertEq(usdc.balanceOf(liquidator), 800000);
     }
 }

--- a/test/controller/LiquidationCall.t.sol
+++ b/test/controller/LiquidationCall.t.sol
@@ -27,9 +27,9 @@ contract TestControllerLiquidationCall is TestController {
         weth.approve(address(controller), type(uint256).max);
 
         vm.prank(user2);
-        controller.supplyToken(1, 1e10);
+        controller.supplyToken(1, 1e10, true);
         vm.prank(user2);
-        controller.supplyToken(2, 1e10);
+        controller.supplyToken(1, 1e10, false);
 
         // create vault
         vaultId = controller.updateMargin(1e8);

--- a/test/controller/ProtocolInsolvency.t.sol
+++ b/test/controller/ProtocolInsolvency.t.sol
@@ -92,12 +92,12 @@ contract TestControllerTradePerp is TestController {
         controller.withdrawToken(WBTC_ASSET_ID, 1e18, true);
         controller.withdrawToken(WBTC_ASSET_ID, 1e18, false);
         vm.stopPrank();
-        
+
         console.log(usdc.balanceOf(address(controller)));
         console.log(weth.balanceOf(address(controller)));
 
         for (uint256 i = 1; i <= 2; i++) {
-            DataType.AssetStatus memory asset = controller.getAsset(i);
+            DataType.PairStatus memory asset = controller.getAsset(i);
 
             if (asset.underlyingPool.accumulatedProtocolRevenue > 0 || asset.stablePool.accumulatedProtocolRevenue > 0)
             {

--- a/test/controller/Reallocate.t.sol
+++ b/test/controller/Reallocate.t.sol
@@ -25,9 +25,10 @@ contract TestControllerReallocate is TestController {
         weth.approve(address(controller), type(uint256).max);
         wbtc.approve(address(controller), type(uint256).max);
 
-        controller.supplyToken(STABLE_ASSET_ID, 1e10);
-        controller.supplyToken(WETH_ASSET_ID, 1e10);
-        controller.supplyToken(WBTC_ASSET_ID, 1e10);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, true);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, false);
+        controller.supplyToken(WBTC_ASSET_ID, 1e10, true);
+        controller.supplyToken(WBTC_ASSET_ID, 1e10, false);
         vm.stopPrank();
 
         // create vault
@@ -57,7 +58,7 @@ contract TestControllerReallocate is TestController {
 
     function testCannotReallocateStableAsset() public {
         vm.expectRevert(bytes("ASSETID"));
-        controller.reallocate(STABLE_ASSET_ID);
+        controller.reallocate(0);
     }
 
     function testCannotReallocateInvalidAssetId() public {

--- a/test/controller/Setup.t.sol
+++ b/test/controller/Setup.t.sol
@@ -13,9 +13,8 @@ import "../mocks/MockERC20.sol";
 contract TestController is Test {
     uint256 internal constant RISK_RATIO = 109544511;
 
-    uint256 internal constant STABLE_ASSET_ID = 1;
-    uint256 internal constant WETH_ASSET_ID = 2;
-    uint256 internal constant WBTC_ASSET_ID = 3;
+    uint256 internal constant WETH_ASSET_ID = 1;
+    uint256 internal constant WBTC_ASSET_ID = 2;
 
     Controller internal controller;
     MockERC20 internal usdc;
@@ -117,13 +116,13 @@ contract TestController is Test {
         DataType.AddAssetParams[] memory addAssetParams = new DataType.AddAssetParams[](2);
 
         addAssetParams[0] = DataType.AddAssetParams(
-            address(uniswapPool), DataType.AssetRiskParams(RISK_RATIO, 1000, 500), irmParams, irmParams
+            address(uniswapPool), DataType.AssetRiskParams(RISK_RATIO, 1000, 500), irmParams, irmParams, irmParams
         );
         addAssetParams[1] = DataType.AddAssetParams(
-            address(wbtcUniswapPool), DataType.AssetRiskParams(RISK_RATIO, 1000, 500), irmParams, irmParams
+            address(wbtcUniswapPool), DataType.AssetRiskParams(RISK_RATIO, 1000, 500), irmParams, irmParams, irmParams
         );
 
-        controller.initialize(address(usdc), irmParams, addAssetParams);
+        controller.initialize(address(usdc), addAssetParams);
     }
 
     function getTradeParamsWithTokenId(uint256 _tokenId, int256 _tradeAmount, int256 _tradeSqrtAmount)
@@ -161,6 +160,6 @@ contract TestController is Test {
     function getSupplyTokenAddress(uint256 _assetId) internal view returns (address supplyTokenAddress) {
         DataType.AssetStatus memory asset = controller.getAsset(_assetId);
 
-        return asset.supplyTokenAddress;
+        return asset.underlyingPool.supplyTokenAddress;
     }
 }

--- a/test/controller/Setup.t.sol
+++ b/test/controller/Setup.t.sol
@@ -157,8 +157,8 @@ contract TestController is Test {
         return (controller.getSqrtPrice(_tokenId) * 120) / 100;
     }
 
-    function getSupplyTokenAddress(uint256 _assetId) internal view returns (address supplyTokenAddress) {
-        DataType.AssetStatus memory asset = controller.getAsset(_assetId);
+    function getSupplyTokenAddress(uint256 _pairId) internal view returns (address supplyTokenAddress) {
+        DataType.PairStatus memory asset = controller.getAsset(_pairId);
 
         return asset.underlyingPool.supplyTokenAddress;
     }

--- a/test/controller/SupplyToken.t.sol
+++ b/test/controller/SupplyToken.t.sol
@@ -10,18 +10,18 @@ contract TestControllerSupplyToken is TestController {
 
     // supply token
     function testSupplyToken() public {
-        controller.supplyToken(WETH_ASSET_ID, 100);
+        controller.supplyToken(WETH_ASSET_ID, 100, false);
 
         assertEq(IERC20(getSupplyTokenAddress(WETH_ASSET_ID)).balanceOf(address(this)), 100);
     }
 
     function testCannotSupplyToken_IfAssetIdIsZero() public {
         vm.expectRevert(bytes("A0"));
-        controller.supplyToken(0, 100);
+        controller.supplyToken(0, 100, false);
     }
 
     function testCannotSupplyToken_IfAssetIdIsNotExisted() public {
         vm.expectRevert(bytes("A0"));
-        controller.supplyToken(4, 100);
+        controller.supplyToken(4, 100, false);
     }
 }

--- a/test/controller/TradePerp.t.sol
+++ b/test/controller/TradePerp.t.sol
@@ -80,7 +80,7 @@ contract TestControllerTradePerp is TestController {
         controller.withdrawToken(1, 1e18, false);
 
         {
-            DataType.AssetStatus memory asset = controller.getAsset(1);
+            DataType.PairStatus memory asset = controller.getAsset(1);
 
             if (asset.underlyingPool.accumulatedProtocolRevenue > 0 || asset.stablePool.accumulatedProtocolRevenue > 0)
             {

--- a/test/controller/TradePerp.t.sol
+++ b/test/controller/TradePerp.t.sol
@@ -256,7 +256,7 @@ contract TestControllerTradePerp is TestController {
 
         controller.tradePerp(vaultId, WETH_ASSET_ID, getTradeParams(0, -1 * 1e6));
 
-        (uint256 ur,) = controller.getUtilizationRatio(WETH_ASSET_ID);
+        (uint256 ur,,) = controller.getUtilizationRatio(WETH_ASSET_ID);
 
         assertEq(ur, 1e18);
 
@@ -673,7 +673,7 @@ contract TestControllerTradePerp is TestController {
 
         assertEq(tradeResult.minDeposit, 1000000);
 
-        (uint256 ur,) = controller.getUtilizationRatio(WETH_ASSET_ID);
+        (uint256 ur,,) = controller.getUtilizationRatio(WETH_ASSET_ID);
 
         assertEq(ur, 5 * 1e17);
 

--- a/test/controller/UniswapCallback.t.sol
+++ b/test/controller/UniswapCallback.t.sol
@@ -18,7 +18,7 @@ contract TestControllerUniswapCallback is TestController {
         usdc.approve(address(controller), type(uint256).max);
 
         vm.prank(user);
-        controller.supplyToken(STABLE_ASSET_ID, 1e10);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, true);
 
         mockAttack = new MockAttack(address(usdc), address(usdc));
     }

--- a/test/controller/UpdateMargin.t.sol
+++ b/test/controller/UpdateMargin.t.sol
@@ -23,8 +23,8 @@ contract TestControllerUpdateMargin is TestController {
         vm.prank(user2);
         vaultId2 = controller.updateMargin(1000 * 1e6);
 
-        controller.supplyToken(1, 1e10);
-        controller.supplyToken(2, 1e10);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, true);
+        controller.supplyToken(WETH_ASSET_ID, 1e10, false);
     }
 
     function testDepositMargin_IfAccountAlreadyHasMainVault() public {

--- a/test/controller/UpdateParams.t.sol
+++ b/test/controller/UpdateParams.t.sol
@@ -32,7 +32,7 @@ contract TestControllerUpdateParams is TestController {
 
         uint256 assetId = controller.addPair(addPairParams);
 
-        DataType.AssetStatus memory asset = controller.getAsset(assetId);
+        DataType.PairStatus memory asset = controller.getAsset(assetId);
 
         assertEq(asset.id, 3);
     }
@@ -51,7 +51,7 @@ contract TestControllerUpdateParams is TestController {
     function testUpdateAssetRiskParams() public {
         controller.updateAssetRiskParams(WETH_ASSET_ID, DataType.AssetRiskParams(110000000, 20, 10));
 
-        DataType.AssetStatus memory asset = controller.getAsset(WETH_ASSET_ID);
+        DataType.PairStatus memory asset = controller.getAsset(WETH_ASSET_ID);
 
         assertEq(asset.riskParams.riskRatio, 110000000);
         assertEq(asset.riskParams.rangeSize, 20);
@@ -77,7 +77,7 @@ contract TestControllerUpdateParams is TestController {
     function testUpdateAssetIRMParams() public {
         controller.updateIRMParams(WETH_ASSET_ID, newIrmParams, newIrmParams, newIrmParams);
 
-        DataType.AssetStatus memory asset = controller.getAsset(WETH_ASSET_ID);
+        DataType.PairStatus memory asset = controller.getAsset(WETH_ASSET_ID);
 
         assertEq(asset.stablePool.irmParams.baseRate, 2 * 1e16);
         assertEq(asset.stablePool.irmParams.kinkRate, 10 * 1e17);

--- a/test/controller/WithdrawToken.t.sol
+++ b/test/controller/WithdrawToken.t.sol
@@ -40,24 +40,24 @@ contract TestControllerWithdrawToken is TestController {
     }
 
     function testCannotWithdrawToken_IfAssetIdIsZero() public {
-        controller.supplyToken(WETH_ASSET_ID, 100);
+        controller.supplyToken(WETH_ASSET_ID, 100, false);
 
         vm.expectRevert(bytes("A0"));
-        controller.withdrawToken(0, 100);
+        controller.withdrawToken(0, 100, false);
     }
 
     function testCannotWithdrawToken_IfAssetIdIsNotExisted() public {
-        controller.supplyToken(WETH_ASSET_ID, 100);
+        controller.supplyToken(WETH_ASSET_ID, 100, false);
 
         vm.expectRevert(bytes("A0"));
-        controller.withdrawToken(4, 100);
+        controller.withdrawToken(4, 100, false);
     }
 
     // withdraw token
     function testWithdrawToken() public {
-        controller.supplyToken(WETH_ASSET_ID, 100);
+        controller.supplyToken(WETH_ASSET_ID, 100, false);
 
-        controller.withdrawToken(WETH_ASSET_ID, 100);
+        controller.withdrawToken(WETH_ASSET_ID, 100, false);
 
         assertEq(IERC20(getSupplyTokenAddress(WETH_ASSET_ID)).balanceOf(address(this)), 0);
     }
@@ -65,7 +65,7 @@ contract TestControllerWithdrawToken is TestController {
     // cannot withdraw token if asset utilization is not 0
     function testCannotWithdrawTokenIfNoEnoughUnderlyingAsset() public {
         vm.prank(user1);
-        controller.supplyToken(WETH_ASSET_ID, 1e6);
+        controller.supplyToken(WETH_ASSET_ID, 1e6, false);
 
         vm.startPrank(user2);
         controller.tradePerp(vaultId, WETH_ASSET_ID, getTradeParams(-100, 0));
@@ -73,13 +73,13 @@ contract TestControllerWithdrawToken is TestController {
 
         vm.prank(user1);
         vm.expectRevert(bytes("S0"));
-        controller.withdrawToken(WETH_ASSET_ID, 1e6);
+        controller.withdrawToken(WETH_ASSET_ID, 1e6, false);
     }
 
     // cannot withdraw token if asset utilization is not 0
     function testCannotWithdrawTokenIfNoEnoughStableAsset() public {
         vm.prank(user1);
-        controller.supplyToken(STABLE_ASSET_ID, 1e6);
+        controller.supplyToken(WETH_ASSET_ID, 1e6, true);
 
         vm.startPrank(user2);
         controller.tradePerp(vaultId, WETH_ASSET_ID, getTradeParams(100, 0));
@@ -87,6 +87,6 @@ contract TestControllerWithdrawToken is TestController {
 
         vm.prank(user1);
         vm.expectRevert(bytes("S0"));
-        controller.withdrawToken(STABLE_ASSET_ID, 1e6);
+        controller.withdrawToken(WETH_ASSET_ID, 1e6, true);
     }
 }

--- a/test/helper/Helper.sol
+++ b/test/helper/Helper.sol
@@ -6,13 +6,13 @@ import "../../src/Controller.sol";
 contract Helper {
     uint256 internal constant RISK_RATIO = 109544511;
 
-    function createAssetStatus(uint256 _assetId, address _weth, address _uniswapPool)
+    function createAssetStatus(uint256 _pairId, address _weth, address _uniswapPool)
         internal
         view
-        returns (DataType.AssetStatus memory assetStatus)
+        returns (DataType.PairStatus memory assetStatus)
     {
-        assetStatus = DataType.AssetStatus(
-            _assetId,
+        assetStatus = DataType.PairStatus(
+            _pairId,
             DataType.AssetPoolStatus(
                 address(0),
                 address(0),

--- a/test/helper/Helper.sol
+++ b/test/helper/Helper.sol
@@ -8,6 +8,7 @@ contract Helper {
 
     function createAssetStatus(uint256 _assetId, address _weth, address _uniswapPool)
         internal
+        view
         returns (DataType.AssetStatus memory assetStatus)
     {
         assetStatus = DataType.AssetStatus(

--- a/test/helper/Helper.sol
+++ b/test/helper/Helper.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "../../src/Controller.sol";
+
+contract Helper {
+    uint256 internal constant RISK_RATIO = 109544511;
+
+    function createAssetStatus(uint256 _assetId, address _weth, address _uniswapPool)
+        internal
+        returns (DataType.AssetStatus memory assetStatus)
+    {
+        assetStatus = DataType.AssetStatus(
+            _assetId,
+            DataType.AssetPoolStatus(
+                address(0),
+                address(0),
+                ScaledAsset.createTokenStatus(),
+                InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
+                0
+            ),
+            DataType.AssetPoolStatus(
+                _weth,
+                address(0),
+                ScaledAsset.createTokenStatus(),
+                InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
+                0
+            ),
+            DataType.AssetRiskParams(RISK_RATIO, 1000, 500),
+            Perp.createAssetStatus(_uniswapPool, -100, 100),
+            false,
+            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
+            block.timestamp
+        );
+
+        assetStatus.sqrtAssetStatus.supplyPremiumGrowth = 1 * 1e16;
+        assetStatus.sqrtAssetStatus.borrowPremiumGrowth = 2 * 1e16;
+        assetStatus.sqrtAssetStatus.fee0Growth = 200 * 1e12;
+        assetStatus.sqrtAssetStatus.fee1Growth = 5 * 1e12;
+    }
+}

--- a/test/perp/Reallocate.t.sol
+++ b/test/perp/Reallocate.t.sol
@@ -8,15 +8,14 @@ contract TestPerpReallocate is TestPerp {
     function setUp() public override {
         TestPerp.setUp();
 
-        ScaledAsset.addAsset(underlyingAssetStatus.tokenStatus, 1000000);
-        ScaledAsset.addAsset(stableAssetStatus, 1000000);
+        ScaledAsset.addAsset(underlyingAssetStatus.underlyingPool.tokenStatus, 1000000);
+        ScaledAsset.addAsset(underlyingAssetStatus.stablePool.tokenStatus, 1000000);
     }
 
     function testReallocate() public {
         Perp.computeRequiredAmounts(underlyingAssetStatus, userStatus, 1000000);
         Perp.updatePosition(
             underlyingAssetStatus,
-            stableAssetStatus,
             userStatus,
             Perp.UpdatePerpParams(-100, 100),
             Perp.UpdateSqrtPerpParams(1000000, -100)
@@ -24,7 +23,7 @@ contract TestPerpReallocate is TestPerp {
 
         uniswapPool.swap(address(this), false, 10000, TickMath.MAX_SQRT_RATIO - 1, "");
 
-        Perp.reallocate(underlyingAssetStatus, stableAssetStatus, underlyingAssetStatus.sqrtAssetStatus, false);
+        Perp.reallocate(underlyingAssetStatus, underlyingAssetStatus.sqrtAssetStatus, false);
 
         assertEq(underlyingAssetStatus.sqrtAssetStatus.tickLower, -900);
         assertEq(underlyingAssetStatus.sqrtAssetStatus.tickUpper, 1090);

--- a/test/perp/Setup.t.sol
+++ b/test/perp/Setup.t.sol
@@ -8,10 +8,9 @@ import {TransferHelper} from "@uniswap/v3-periphery/contracts/libraries/Transfer
 import "../../src/libraries/Perp.sol";
 import "../mocks/MockERC20.sol";
 import "../../src/libraries/InterestRateModel.sol";
+import "../helper/Helper.sol";
 
-contract TestPerp is Test {
-    uint256 internal constant RISK_RATIO = 109544511;
-
+contract TestPerp is Test, Helper {
     MockERC20 internal usdc;
     MockERC20 internal weth;
     address internal token0;
@@ -19,7 +18,6 @@ contract TestPerp is Test {
     IUniswapV3Pool internal uniswapPool;
 
     DataType.AssetStatus internal underlyingAssetStatus;
-    ScaledAsset.TokenStatus internal stableAssetStatus;
     Perp.UserStatus internal userStatus;
 
     function setUp() public virtual {
@@ -48,24 +46,12 @@ contract TestPerp is Test {
 
         uniswapPool.mint(address(this), -1000, 1000, 1000000, bytes(""));
 
-        underlyingAssetStatus = DataType.AssetStatus(
-            1,
-            address(weth),
-            address(0),
-            DataType.AssetRiskParams(RISK_RATIO, 1000, 500),
-            ScaledAsset.createTokenStatus(),
-            Perp.createAssetStatus(address(uniswapPool), -100, 100),
-            !isTokenAToken0,
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            block.timestamp,
-            0
-        );
-        stableAssetStatus = ScaledAsset.createTokenStatus();
+        underlyingAssetStatus = createAssetStatus(1, address(weth), address(uniswapPool));
+
         userStatus = Perp.createPerpUserStatus();
 
-        ScaledAsset.addAsset(underlyingAssetStatus.tokenStatus, 1e8);
-        ScaledAsset.addAsset(stableAssetStatus, 1e8);
+        ScaledAsset.addAsset(underlyingAssetStatus.underlyingPool.tokenStatus, 1e8);
+        ScaledAsset.addAsset(underlyingAssetStatus.stablePool.tokenStatus, 1e8);
     }
 
     function uniswapV3MintCallback(uint256 amount0, uint256 amount1, bytes calldata) external {

--- a/test/perp/Setup.t.sol
+++ b/test/perp/Setup.t.sol
@@ -17,7 +17,7 @@ contract TestPerp is Test, Helper {
     address internal token1;
     IUniswapV3Pool internal uniswapPool;
 
-    DataType.AssetStatus internal underlyingAssetStatus;
+    DataType.PairStatus internal underlyingAssetStatus;
     Perp.UserStatus internal userStatus;
 
     function setUp() public virtual {

--- a/test/perp/UpdatePosition.t.sol
+++ b/test/perp/UpdatePosition.t.sol
@@ -13,11 +13,7 @@ contract TestPerpUpdatePosition is TestPerp {
         userStatus2 = Perp.createPerpUserStatus();
 
         Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus2,
-            Perp.UpdatePerpParams(100, -100),
-            Perp.UpdateSqrtPerpParams(100, -100)
+            underlyingAssetStatus, userStatus2, Perp.UpdatePerpParams(100, -100), Perp.UpdateSqrtPerpParams(100, -100)
         );
     }
 
@@ -25,22 +21,14 @@ contract TestPerpUpdatePosition is TestPerp {
     function testCannotOpenLong() public {
         vm.expectRevert(bytes("S0"));
         Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus,
-            Perp.UpdatePerpParams(1e18, -1e18),
-            Perp.UpdateSqrtPerpParams(0, 0)
+            underlyingAssetStatus, userStatus, Perp.UpdatePerpParams(1e18, -1e18), Perp.UpdateSqrtPerpParams(0, 0)
         );
     }
 
     // Opens long position
     function testOpenLong() public {
         Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus,
-            Perp.UpdatePerpParams(10, -100),
-            Perp.UpdateSqrtPerpParams(10, -100)
+            underlyingAssetStatus, userStatus, Perp.UpdatePerpParams(10, -100), Perp.UpdateSqrtPerpParams(10, -100)
         );
 
         assertEq(userStatus.perp.amount, 10);
@@ -64,11 +52,7 @@ contract TestPerpUpdatePosition is TestPerp {
     // Closes long position
     function testCloseLong() public {
         Perp.Payoff memory payoff = Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus2,
-            Perp.UpdatePerpParams(-100, 200),
-            Perp.UpdateSqrtPerpParams(0, 0)
+            underlyingAssetStatus, userStatus2, Perp.UpdatePerpParams(-100, 200), Perp.UpdateSqrtPerpParams(0, 0)
         );
 
         assertEq(payoff.perpPayoff, 100);
@@ -79,11 +63,7 @@ contract TestPerpUpdatePosition is TestPerp {
 
     function testCloseSqrtLong() public {
         Perp.Payoff memory payoff = Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus2,
-            Perp.UpdatePerpParams(0, 0),
-            Perp.UpdateSqrtPerpParams(-100, 200)
+            underlyingAssetStatus, userStatus2, Perp.UpdatePerpParams(0, 0), Perp.UpdateSqrtPerpParams(-100, 200)
         );
 
         assertEq(payoff.perpPayoff, 0);
@@ -94,11 +74,7 @@ contract TestPerpUpdatePosition is TestPerp {
 
     function testCloseLongPartially() public {
         Perp.Payoff memory payoff = Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus2,
-            Perp.UpdatePerpParams(-50, 100),
-            Perp.UpdateSqrtPerpParams(0, 0)
+            underlyingAssetStatus, userStatus2, Perp.UpdatePerpParams(-50, 100), Perp.UpdateSqrtPerpParams(0, 0)
         );
 
         assertEq(payoff.perpPayoff, 50);
@@ -109,11 +85,7 @@ contract TestPerpUpdatePosition is TestPerp {
 
     function testCloseLongAndOpenShort() public {
         Perp.Payoff memory payoff = Perp.updatePosition(
-            underlyingAssetStatus,
-            stableAssetStatus,
-            userStatus2,
-            Perp.UpdatePerpParams(-200, 400),
-            Perp.UpdateSqrtPerpParams(0, 0)
+            underlyingAssetStatus, userStatus2, Perp.UpdatePerpParams(-200, 400), Perp.UpdateSqrtPerpParams(0, 0)
         );
 
         assertEq(payoff.perpPayoff, 100);
@@ -126,7 +98,6 @@ contract TestPerpUpdatePosition is TestPerp {
     function testOpenGammaShort() public {
         Perp.updatePosition(
             underlyingAssetStatus,
-            stableAssetStatus,
             userStatus,
             Perp.UpdatePerpParams(-1e6, 1e6),
             Perp.UpdateSqrtPerpParams(1e6, -2 * 1e6)

--- a/test/position/CalculateMinDeposit.t.sol
+++ b/test/position/CalculateMinDeposit.t.sol
@@ -5,7 +5,7 @@ import "./Setup.t.sol";
 import "../../src/libraries/PositionCalculator.sol";
 
 contract CalculateMinDepositTest is TestPositionCalculator {
-    mapping(uint256 => DataType.AssetStatus) assets;
+    mapping(uint256 => DataType.PairStatus) assets;
 
     function setUp() public override {
         TestPositionCalculator.setUp();

--- a/test/position/CalculateMinDeposit.t.sol
+++ b/test/position/CalculateMinDeposit.t.sol
@@ -10,47 +10,9 @@ contract CalculateMinDepositTest is TestPositionCalculator {
     function setUp() public override {
         TestPositionCalculator.setUp();
 
-        assets[1] = DataType.AssetStatus(
-            1,
-            address(0),
-            address(0),
-            DataType.AssetRiskParams(0, 1000, 500),
-            ScaledAsset.createTokenStatus(),
-            Perp.createAssetStatus(address(0), -100, 100),
-            false,
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            block.timestamp,
-            0
-        );
-
-        assets[2] = DataType.AssetStatus(
-            2,
-            address(0),
-            address(0),
-            DataType.AssetRiskParams(RISK_RATIO, 1000, 500),
-            ScaledAsset.createTokenStatus(),
-            Perp.createAssetStatus(address(uniswapPool), -100, 100),
-            false,
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            block.timestamp,
-            0
-        );
-
-        assets[3] = DataType.AssetStatus(
-            3,
-            address(0),
-            address(0),
-            DataType.AssetRiskParams(RISK_RATIO, 1000, 500),
-            ScaledAsset.createTokenStatus(),
-            Perp.createAssetStatus(address(wbtcUniswapPool), -100, 100),
-            false,
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            InterestRateModel.IRMParams(0, 9 * 1e17, 1e17, 1e18),
-            block.timestamp,
-            0
-        );
+        assets[1] = createAssetStatus(1, address(0), address(0));
+        assets[2] = createAssetStatus(2, address(0), address(uniswapPool));
+        assets[3] = createAssetStatus(3, address(0), address(wbtcUniswapPool));
     }
 
     function getVault(int256 _amountStable, int256 _amountSquart, int256 _amountUnderlying, int256 _margin)

--- a/test/position/Setup.t.sol
+++ b/test/position/Setup.t.sol
@@ -8,10 +8,9 @@ import "@uniswap/v3-core/contracts/interfaces/pool/IUniswapV3PoolActions.sol";
 import {TransferHelper} from "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
 import "../../src/libraries/InterestRateModel.sol";
 import "../mocks/MockERC20.sol";
+import "../helper/Helper.sol";
 
-contract TestPositionCalculator is Test {
-    uint256 internal constant RISK_RATIO = 109544511;
-
+contract TestPositionCalculator is Test, Helper {
     MockERC20 internal usdc;
     MockERC20 internal weth;
     MockERC20 internal wbtc;

--- a/test/strategy/GammaShortStrategy.t.sol
+++ b/test/strategy/GammaShortStrategy.t.sol
@@ -22,8 +22,8 @@ contract TestGammaShortStrategy is TestBaseStrategy {
 
         reader = new Reader(controller);
 
-        controller.supplyToken(1, 1e15);
-        controller.supplyToken(2, 1e15);
+        controller.supplyToken(WETH_ASSET_ID, 1e15, true);
+        controller.supplyToken(WETH_ASSET_ID, 1e15, false);
 
         strategy = new GammaShortStrategy();
 
@@ -140,13 +140,13 @@ contract TestGammaShortStrategy is TestBaseStrategy {
         }
 
         controller.tradePerp(
-            lpVaultId, 2, TradeLogic.TradeParams(1e8, -1e8, 0, type(uint160).max, block.timestamp, false, "")
+            lpVaultId, 1, TradeLogic.TradeParams(1e8, -1e8, 0, type(uint160).max, block.timestamp, false, "")
         );
 
         vm.warp(block.timestamp + 10 weeks);
 
         controller.tradePerp(
-            lpVaultId, 2, TradeLogic.TradeParams(-1e8, 1e8, 0, type(uint160).max, block.timestamp, false, "")
+            lpVaultId, 1, TradeLogic.TradeParams(-1e8, 1e8, 0, type(uint160).max, block.timestamp, false, "")
         );
 
         uint256 withdrawAmount = strategy.withdraw(1e10, address(this), 0, getStrategyTradeParams());
@@ -299,9 +299,9 @@ contract TestGammaShortStrategy is TestBaseStrategy {
         assertFalse(strategy.checkPriceHedge());
         assertTrue(strategy.checkTimeHedge());
 
-        assertEq(reader.getDelta(2, strategy.vaultId()), -2399999972);
+        assertEq(reader.getDelta(WETH_ASSET_ID, strategy.vaultId()), -2399999972);
         strategy.execDeltaHedge(getStrategyTradeParams(), 1e18);
-        assertEq(reader.getDelta(2, strategy.vaultId()), -29);
+        assertEq(reader.getDelta(WETH_ASSET_ID, strategy.vaultId()), -29);
 
         uint256 withdrawMarginAmount = strategy.withdraw(1e10, address(this), 0, getStrategyTradeParams());
 
@@ -325,14 +325,14 @@ contract TestGammaShortStrategy is TestBaseStrategy {
         assertFalse(strategy.checkPriceHedge());
         assertTrue(strategy.checkTimeHedge());
 
-        assertEq(reader.getDelta(2, strategy.vaultId()), -2399999972);
+        assertEq(reader.getDelta(WETH_ASSET_ID, strategy.vaultId()), -2399999972);
         strategy.execDeltaHedge(getStrategyTradeParams(), 5 * 1e17);
 
-        assertEq(reader.getDelta(2, strategy.vaultId()), -1200000000);
+        assertEq(reader.getDelta(WETH_ASSET_ID, strategy.vaultId()), -1200000000);
 
         strategy.execDeltaHedge(getStrategyTradeParams(), 1e18);
 
-        assertEq(reader.getDelta(2, strategy.vaultId()), -15);
+        assertEq(reader.getDelta(WETH_ASSET_ID, strategy.vaultId()), -15);
 
         assertFalse(strategy.checkTimeHedge());
     }

--- a/test/strategy/Setup.t.sol
+++ b/test/strategy/Setup.t.sol
@@ -23,7 +23,7 @@ contract TestBaseStrategy is Test {
     IUniswapV3Pool internal uniswapPool;
     InterestRateModel.IRMParams internal irmParams;
 
-    DataType.AssetStatus internal underlyingAssetStatus;
+    DataType.PairStatus internal underlyingAssetStatus;
 
     function setUp() public virtual {
         irmParams = InterestRateModel.IRMParams(1e16, 9 * 1e17, 5 * 1e17, 1e18);

--- a/test/strategy/Setup.t.sol
+++ b/test/strategy/Setup.t.sol
@@ -13,8 +13,7 @@ import "../mocks/MockERC20.sol";
 contract TestBaseStrategy is Test {
     uint256 internal constant RISK_RATIO = 109544511;
 
-    uint256 internal constant STABLE_ASSET_ID = 1;
-    uint256 internal constant WETH_ASSET_ID = 2;
+    uint256 internal constant WETH_ASSET_ID = 1;
 
     Controller internal controller;
     MockERC20 internal usdc;
@@ -102,9 +101,9 @@ contract TestBaseStrategy is Test {
         DataType.AddAssetParams[] memory addAssetParams = new DataType.AddAssetParams[](1);
 
         addAssetParams[0] = DataType.AddAssetParams(
-            address(uniswapPool), DataType.AssetRiskParams(RISK_RATIO, 1000, 500), irmParams, irmParams
+            address(uniswapPool), DataType.AssetRiskParams(RISK_RATIO, 1000, 500), irmParams, irmParams, irmParams
         );
 
-        controller.initialize(address(usdc), irmParams, addAssetParams);
+        controller.initialize(address(usdc), addAssetParams);
     }
 }


### PR DESCRIPTION
Making changes that one AssetStatus has two pools, stable and underlying.
So, AssetStatus should be renamed PairStatus.

Stable pools are isolated by underlying assets.
Therefore an attacker can only borrow a corresponding stable pool for underlying positions.
Even if the attacker makes fake unrealized profit by price manipulation, they can't borrow other underlying assets by the profit.
